### PR TITLE
Adding support for kubernetes credentials provider plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 * In order to do this, CrowdStrike is offering solutions for developers at build time that allow them to assess their Docker container images and review summarized report data integrated with their favorite CI/CD tools like Jenkins.
 * Customers will use this feature by downloading from Falcon console, and following Falcon documentation to install our plugins on top of their existing self-hosted CI/CD solutions.
 * Customers will then generate a new authentication token within Falcon console, and configure their plugin to use this credential for communication with existing Falcon APIs.
-* Users of this plugin receive a unique HTML view of the Image Assessment report data embedded inside Jenkins. 
+* Users of this plugin receive a unique HTML view of the Image Assessment report data embedded inside Jenkins.
 * Users of this plugin can choose to use the information Falcon provides to actively abort the deployment of vulnerable container images as an in-line step in the build pipeline.
 
 ## About the Image Assessment feature
 
-**Image Assessment** is focused on identifying vulnerabilities in container images.   
+**Image Assessment** is focused on identifying vulnerabilities in container images.
 This plugin is leveraging that existing feature of Falcon via the Falcon API.
 
 For more information about CrowdStrike's Image Assessment feature:
@@ -43,7 +43,7 @@ For more information about CrowdStrike's Image Assessment feature:
   - Install the plugin.
 - #### Manual Installation
   - Download the latest stable release version of this plugin from Falcon console.
-      * `Falcon console > Support > Tool Downloads`  
+      * `Falcon console > Support > Tool Downloads`
       * Click to download `CrowdStrike Security for Jenkins` file archive.
       * Extract the `.zip` archive locally.
       * Look for the `.hpi` file which is the format of a Jenkins plugin.
@@ -80,7 +80,7 @@ You can fill them in manually, or use the automatic configuration option (ie. if
 
 - In Jenkins, navigate to `Manage Jenkins > Configure System > CrowdStrike Security`,
     * Select the `Credential ID` (generated above).
-    * Select a `Falcon Cloud` from the dropdown menu. 
+    * Select a `Falcon Cloud` from the dropdown menu.
     * Click the `Save` button.
 
 #### Q: What is the Falcon Cloud?
@@ -196,7 +196,7 @@ These settings must be specified for each Jenkins job, where the plugin is inten
 
 - Enter the following details:
     * For `When image does not comply with policy`, choose one:
-      * `Enforce the recommendation`: if Falcon policy is set to "Prevent", Jenkins will **enforce** this by failing the build.  
+      * `Enforce the recommendation`: if Falcon policy is set to "Prevent", Jenkins will **enforce** this by failing the build.
          (You will still receive an Image Assessment report.)
       * `Skip image upload`: Select this option only if the image is already uploaded to CrowdStrike as part of a previous step. When selected, the plugin will **not execute** `docker push`. It only retrieves the image scan report but does not upload the image to CrowdStrike for assessment.
     * Image to assess:
@@ -204,7 +204,7 @@ These settings must be specified for each Jenkins job, where the plugin is inten
         * `Image Tag`: tag of the docker image that will be scanned by CrowdStrike Image Assessment.
         * `Timeout`: how to long to wait (in seconds) before failing build, if unable to communicate with Falcon API.
 
-**NOTICE:** if `Enforce the recommendation` option is not set, the plugin assumes `docker` binary is installed and in `$PATH`, and that it is already configured to connect to a running Docker Engine, where images will be pulled-to/pushed-from.  
+**NOTICE:** if `Enforce the recommendation` option is not set, the plugin assumes `docker` binary is installed and in `$PATH`, and that it is already configured to connect to a running Docker Engine, where images will be pulled-to/pushed-from.
 **NOTICE:** You may use environment `$VARIABLES` in the field values above. (e.g., if Docker image tag is incrementing per-build)
 
 ![Per job](docs/images/per_job_config.png)
@@ -243,6 +243,32 @@ Schedule the job to run normally, and the report will be stored among the job ou
 
 ![Report Fail](docs/images/build_blocked.png)
 
+## Kubernetes Integration
+
+This plugin integrates with the [Kubernetes Credentials Provider Plugin](https://plugins.jenkins.io/kubernetes-credentials-provider/) to support automatic creation of CrowdStrike credentials from Kubernetes secrets.
+
+### Prerequisites
+- Jenkins running in a Kubernetes cluster
+- [Kubernetes Credentials Provider Plugin](https://plugins.jenkins.io/kubernetes-credentials-provider/) installed in Jenkins
+
+### Usage
+
+Create a Kubernetes secret with the following format:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: crowdstrike-creds
+  annotations:
+    jenkins.io/credentials-description: "CrowdStrike API Credentials"
+  labels:
+    jenkins.io/credentials-type: com.crowdstrike.plugins.crwds.credentials.CredentialsDefault"
+type: Opaque
+data:
+  clientId: <base64-encoded-client-id>
+  clientSecret: <base64-encoded-client-secret>
+```
+
 ## Troubleshooting
 
 Symptom | Possible cause | Solution
@@ -271,11 +297,11 @@ Code | Name | Description
 ### Image
 
 If you want to double-check the vulnerabilities that are found in an existing container image,
-you can use the following tool. 
+you can use the following tool.
 
 #### CrowdStrike IVAN (Image Vulnerability Analysis):
 
-This tool is a command-line container image assessment tool that 
+This tool is a command-line container image assessment tool that
 looks for vulnerabilities in the Docker images.
 It unpacks the image locally, and uploads ONLY METADATA to Falcon, which then returns any known vulnerabilities.
 
@@ -296,14 +322,14 @@ and give them the Policy Name shown in the Image Assessment report data.
 ### Plugin
 
 If you suspect the plugin is the problem, you can try this alternative which is a command-line
-tool. It still talks to Falcon API, and the assessment happens remotely, but it doesn't require Jenkins 
+tool. It still talks to Falcon API, and the assessment happens remotely, but it doesn't require Jenkins
 or this plugin.
 
 Alternatively, you can use the exit code of this script to pass/fail your Jenkins builds.
 
 #### CrowdStrike Container Image Scan
 
-This Python script will upload your container image to Falcon API 
+This Python script will upload your container image to Falcon API
 and return the Image Assessment report data as JSON to stdout.
 This will tell you about known vulnerabilities, malware, and secrets found in the image layers.
 However, it does not support the Image Assessment Policy prevent/alert feature.
@@ -316,4 +342,4 @@ However, it does not support the Image Assessment Policy prevent/alert feature.
   * HOWTO plugin installation
   * Troubleshooting plugin failure (NOT image vulnerability!)
   * Troubleshooting Falcon API response
-  * Configuring Image Assessment Policy  
+  * Configuring Image Assessment Policy

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
 			<groupId>com.cloudbees.jenkins.plugins</groupId>
 			<artifactId>kubernetes-credentials-provider</artifactId>
 			<version>${kubernetes-credentials-provider.version}</version>
+			<optional>true</optional>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,23 @@
 	<properties>
 		<changelist>-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/crowdstrike-security-plugin</gitHubRepo>
-		<jenkins.version>2.332.3</jenkins.version>
+		<jenkins.version>2.462.3</jenkins.version>
 
 		<spotbugs.effort>Max</spotbugs.effort>
 		<spotbugs.failOnError>true</spotbugs.failOnError>
 		<spotbugs.threshold>Low</spotbugs.threshold>
+
+		<kubernetes-credentials-provider.version>1.262.v2670ef7ea_0c5</kubernetes-credentials-provider.version>
+		<jenkins-credentials.version>1271.v54b_1c2c6388a_</jenkins-credentials.version>
+		<jenkins-jackson2-api.version>2.15.2-350.v0c2f3f8fc595</jenkins-jackson2-api.version>
+		<jenkins-bouncycastle-api.version>2.29</jenkins-bouncycastle-api.version>
+		<jenkins-okhttp-api.version>4.11.0-157.v6852a_a_fa_ec11</jenkins-okhttp-api.version>
+		<jenkins-variant.version>59.vf075fe829ccb</jenkins-variant.version>
+		<jenkins-structs.version>324.va_f5d6774f3a_d</jenkins-structs.version>
+		<jenkins-javax-activation-api.version>1.2.0-6</jenkins-javax-activation-api.version>
+		<jenkins-jaxb.version>2.3.8-1</jenkins-jaxb.version>
+		<jenkins-snakeyaml-api.version>1.33-95.va_b_a_e3e47b_fa_4</jenkins-snakeyaml-api.version>
+		<bouncycastle-api.version>2.30.1.78.1-233.vfdcdeb_0a_08a_a_</bouncycastle-api.version>
 	</properties>
 
 	<dependencyManagement>
@@ -63,6 +75,51 @@
 				<version>1210.vcd41f6657f03</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jenkins-ci.plugins</groupId>
+				<artifactId>credentials</artifactId>
+				<version>${jenkins-credentials.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jenkins-ci.plugins</groupId>
+				<artifactId>jackson2-api</artifactId>
+				<version>${jenkins-jackson2-api.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jenkins-ci.plugins</groupId>
+				<artifactId>bouncycastle-api</artifactId>
+				<version>${jenkins-bouncycastle-api.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.jenkins.plugins</groupId>
+				<artifactId>okhttp-api</artifactId>
+				<version>${jenkins-okhttp-api.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jenkins-ci.plugins</groupId>
+				<artifactId>variant</artifactId>
+				<version>${jenkins-variant.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jenkins-ci.plugins</groupId>
+				<artifactId>structs</artifactId>
+				<version>${jenkins-structs.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.jenkins.plugins</groupId>
+				<artifactId>javax-activation-api</artifactId>
+				<version>${jenkins-javax-activation-api.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.jenkins.plugins</groupId>
+				<artifactId>jaxb</artifactId>
+				<version>${jenkins-jaxb.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.jenkins.plugins</groupId>
+				<artifactId>snakeyaml-api</artifactId>
+				<version>${jenkins-snakeyaml-api.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -90,6 +147,18 @@
 			<artifactId>gson</artifactId>
 			<version>2.9.1</version>
 		</dependency>
+		<dependency>
+			<groupId>com.cloudbees.jenkins.plugins</groupId>
+			<artifactId>kubernetes-credentials-provider</artifactId>
+			<version>${kubernetes-credentials-provider.version}</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>bouncycastle-api</artifactId>
+			<version>${bouncycastle-api.version}</version>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 
 	<repositories>
@@ -116,6 +185,16 @@
 					<showWarnings>true</showWarnings>
 					<source>21</source>
 					<target>21</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.jenkins-ci.tools</groupId>
+				<artifactId>maven-hpi-plugin</artifactId>
+				<configuration>
+					<pluginFirstClassLoader>true</pluginFirstClassLoader>
+					<manifestEntries>
+						<Plugin-Dependencies>kubernetes-credentials-provider:${kubernetes-credentials-provider.version};resolution:=optional</Plugin-Dependencies>
+					</manifestEntries>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/com/crowdstrike/plugins/crwds/credentials/KubernetesCredentialConverter.java
+++ b/src/main/java/com/crowdstrike/plugins/crwds/credentials/KubernetesCredentialConverter.java
@@ -1,0 +1,108 @@
+package com.crowdstrike.plugins.crwds.credentials;
+
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.CredentialsConvertionException;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretToCredentialConverter;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.Extension;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Converts Kubernetes secrets to CrowdStrike credentials.
+ * This converter integrates with the Kubernetes Credentials Provider Plugin to enable
+ * automatic creation of CrowdStrike credentials from Kubernetes secrets.
+ */
+@Extension(optional = true)
+public class KubernetesCredentialConverter extends SecretToCredentialConverter {
+    private static final Logger LOGGER = Logger.getLogger(KubernetesCredentialConverter.class.getName());
+    private static final String CREDENTIALS_TYPE = "com.crowdstrike.plugins.crwds.credentials.CredentialsDefault";
+    private static final String CLIENT_ID_FIELD = "clientId";
+    private static final String CLIENT_SECRET_FIELD = "clientSecret";
+    private static final String DESCRIPTION_ANNOTATION = "jenkins.io/credentials-description";
+
+    @Override
+    public boolean canConvert(String type) {
+        LOGGER.log(Level.FINE, "Checking if can convert type: {0}", type);
+        return CREDENTIALS_TYPE.equals(type);
+    }
+
+    @Override
+    public IdCredentials convert(io.fabric8.kubernetes.api.model.Secret secret) throws CredentialsConvertionException {
+        if (secret == null || secret.getMetadata() == null) {
+            throw new CredentialsConvertionException("Secret or its metadata is null");
+        }
+
+        String secretName = secret.getMetadata().getName();
+        LOGGER.log(Level.FINE, "Converting secret: {0}", secretName);
+
+        try {
+            String id = secretName;
+            Map<String, String> annotations = secret.getMetadata().getAnnotations();
+            String description = annotations != null ? annotations.get(DESCRIPTION_ANNOTATION) : "";
+
+            Map<String, String> data = secret.getData();
+            if (data == null) {
+                throw new CredentialsConvertionException("Secret data is null for secret: " + secretName);
+            }
+
+            // Get clientId
+            String clientIdBase64 = Optional.ofNullable(data.get(CLIENT_ID_FIELD))
+                    .orElseThrow(() -> new CredentialsConvertionException(
+                            String.format("No %s found in secret: %s", CLIENT_ID_FIELD, secretName)));
+            String clientId = new String(Base64.getDecoder().decode(clientIdBase64));
+
+            // Get clientSecret
+            String clientSecretBase64 = Optional.ofNullable(data.get(CLIENT_SECRET_FIELD))
+                    .orElseThrow(() -> new CredentialsConvertionException(
+                            String.format("No %s found in secret: %s", CLIENT_SECRET_FIELD, secretName)));
+            String clientSecret = new String(Base64.getDecoder().decode(clientSecretBase64));
+
+            LOGGER.log(Level.FINE, "Successfully converted secret: {0}", secretName);
+
+            // Create a wrapper credential that will be converted to CredentialsDefault
+            return new CredentialsDefaultWrapper(
+                CredentialsScope.GLOBAL,
+                id,
+                description,
+                clientId,
+                clientSecret
+            );
+        } catch (IllegalArgumentException e) {
+            LOGGER.log(Level.WARNING, "Invalid base64 encoding in secret: {0}", secretName);
+            throw new CredentialsConvertionException("Invalid base64 encoding in secret: " + e.getMessage());
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to convert secret: {0}", e.getMessage());
+            throw new CredentialsConvertionException("Failed to convert credentials: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Wrapper class for CredentialsDefault to avoid Secret type issues.
+     */
+    private static class CredentialsDefaultWrapper extends UsernamePasswordCredentialsImpl
+                                                   implements StandardUsernamePasswordCredentials {
+        private final String clientId;
+        private final String clientSecret;
+
+        public CredentialsDefaultWrapper(CredentialsScope scope, String id, String description,
+                                        String clientId, String clientSecret) {
+            super(scope, id, description, clientId, clientSecret);
+            this.clientId = clientId;
+            this.clientSecret = clientSecret;
+        }
+
+        public String getClientId() {
+            return clientId;
+        }
+
+        public String getClientSecret() {
+            return clientSecret;
+        }
+    }
+}

--- a/src/main/java/com/crowdstrike/plugins/crwds/credentials/KubernetesCredentialConverter.java
+++ b/src/main/java/com/crowdstrike/plugins/crwds/credentials/KubernetesCredentialConverter.java
@@ -3,6 +3,7 @@ package com.crowdstrike.plugins.crwds.credentials;
 import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.CredentialsConvertionException;
 import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretToCredentialConverter;
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsDescriptor;
 import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
@@ -85,7 +86,7 @@ public class KubernetesCredentialConverter extends SecretToCredentialConverter {
     /**
      * Wrapper class for CredentialsDefault to avoid Secret type issues.
      */
-    private static class CredentialsDefaultWrapper extends UsernamePasswordCredentialsImpl
+    public static class CredentialsDefaultWrapper extends UsernamePasswordCredentialsImpl
                                                    implements StandardUsernamePasswordCredentials {
         private final String clientId;
         private final String clientSecret;
@@ -103,6 +104,17 @@ public class KubernetesCredentialConverter extends SecretToCredentialConverter {
 
         public String getClientSecret() {
             return clientSecret;
+        }
+
+        /**
+         * Descriptor for CredentialsDefaultWrapper.
+         */
+        @Extension
+        public static class DescriptorImpl extends CredentialsDescriptor {
+            @Override
+            public String getDisplayName() {
+                return "CrowdStrike Credentials (Kubernetes)";
+            }
         }
     }
 }


### PR DESCRIPTION
Add Support for Kubernetes Credentials Provider Plugin

Overview
This PR adds integration with the Kubernetes Credentials Provider Plugin, allowing CrowdStrike credentials to be automatically created from Kubernetes secrets. This enables users to manage Jenkins credentials through Kubernetes, streamlining credential management in containerized environments.

Changes
Added KubernetesCredentialConverter class that implements SecretToCredentialConverter
Created a wrapper credential class with proper descriptor implementation
Configured the Kubernetes Credentials Provider as an optional dependency
Added manifest entry to specify optional plugin dependency resolution

Implementation Details
The implementation allows Kubernetes secrets with the type com.crowdstrike.plugins.crwds.credentials.CredentialsDefault to be automatically converted to CrowdStrike credentials in Jenkins. The converter extracts the client ID and client secret from the Kubernetes secret and creates the appropriate Jenkins credential.

Testing
Tested with Kubernetes Credentials Provider Plugin v1.0.0
Successfully created CrowdStrike credentials from Kubernetes secrets
Verified that the plugin works correctly without the Kubernetes Credentials Provider installed
Usage Example
Users can create a Kubernetes secret like:

yaml
apiVersion: v1
kind: Secret
metadata:
  name: crowdstrike-creds
  annotations:
    jenkins.io/credentials-description: "CrowdStrike API Credentials"
    jenkins.io/credentials-type: "com.crowdstrike.plugins.crwds.credentials.CredentialsDefault"
type: Opaque
data:
  clientId: <base64-encoded-client-id>
  clientSecret: <base64-encoded-client-secret>

Dependencies
This feature requires the Kubernetes Credentials Provider Plugin to be installed
The dependency is marked as optional, so users must explicitly install it

Documentation
Documentation has been updated to include information about this new integration and how to use it.